### PR TITLE
Use ConnectionFactory in the Urban Airship API calls.

### DIFF
--- a/src/com/urbanairship/pushclient/UrbanAirshipAPI.java
+++ b/src/com/urbanairship/pushclient/UrbanAirshipAPI.java
@@ -9,6 +9,8 @@ import javax.microedition.io.HttpConnection;
 import net.rim.device.api.io.Base64OutputStream;
 import net.rim.device.api.io.ConnectionClosedException;
 import net.rim.device.api.io.http.HttpProtocolConstants;
+import net.rim.device.api.io.transport.ConnectionDescriptor;
+import net.rim.device.api.io.transport.ConnectionFactory;
 import net.rim.device.api.system.DeviceInfo;
 import net.rim.device.api.ui.UiApplication;
 
@@ -46,7 +48,11 @@ public class UrbanAirshipAPI {
 			}	
         
 		try {
-			httpConn 		= (HttpConnection) Connector.open(url);
+			ConnectionFactory connFact = new ConnectionFactory();
+			ConnectionDescriptor connDesc;
+			connDesc = connFact.getConnection(url);
+
+			httpConn = (HttpConnection)connDesc.getConnection();
 			httpConn.setRequestMethod(httpVerb);
 			httpConn.setRequestProperty("Authorization", "Basic " + new String(encoded));
 			


### PR DESCRIPTION
The API calls were not working for me, apparently because the transport was not the adequate one. In BB5+ there is a ConnectionFactory class to provide you with the appropriate connection object. The use of this class fixed it for me.
